### PR TITLE
Moving the creation of the configuration class to application. This r…

### DIFF
--- a/application/main.cpp
+++ b/application/main.cpp
@@ -17,11 +17,9 @@ int main()
 
     try
     {
-        auto gameConfiguration = std::make_unique< Core::Configuration >( configSpecification );
-        gameConfiguration->configure();
-
-        Core::Application application;
-        application.setConfiguration( std::move( gameConfiguration ) );
+        // TODO: Change this to an Application Specification that
+        // encapsulates the configSpecification
+        Core::Application application( configSpecification );
         application.initialize();
 
         application.run();

--- a/configs/core_configurables.toml
+++ b/configs/core_configurables.toml
@@ -13,7 +13,7 @@
 logging_enabled = true
 
 [Application.Logger]
-logger_name = "EngineLogger"
+logger_name = "ApplicationLogger"
 global_log_level = "NONE"
 sinks = ["ColorConsoleSink", "TextFileSink"]
 

--- a/libs/core/Application.cpp
+++ b/libs/core/Application.cpp
@@ -18,15 +18,25 @@
 const sf::Time Core::Application::TIME_PER_FRAME = sf::seconds( 1.0f / 120.0f );
 const std::string Core::Application::TYPE_NAME = "Application";
 
-Core::Application::Application() :
+Core::Application::Application( Core::ConfigSpec configSpec ) :
     Configurable( TYPE_NAME ),
-    mConfiguration( nullptr ),
+    mConfiguration( std::make_unique< Core::Configuration >( configSpec ) ),
     mState( State::NONE ),
     mTextures(),
     mNetwork(),
     mStateStack( Core::State::SharedObjects( mWindow, mNetwork, mTextures ) ),
     mWindow( sf::VideoMode( { 640, 480 } ), "Application Window", sf::Style::Close )
-{}
+{
+    // Must call back up to the Configurable
+    std::shared_ptr< ConfigNode > rootNode = ConfigurationTree::instance()->getRootNode();
+    std::vector< std::shared_ptr< Core::ConfigNode > > childrenNodes = rootNode->getChildren();
+    if ( childrenNodes.empty() )
+        throw ConfigurationException( "Children were not populated for RootNode" );
+
+    configure( rootNode );
+
+    return;
+}
 
 void Core::Application::initialize()
 {

--- a/libs/core/Application.hpp
+++ b/libs/core/Application.hpp
@@ -39,7 +39,7 @@ namespace Core
       public:
         static const std::string TYPE_NAME;
 
-        Application();
+        Application( Core::ConfigSpec ConfigSpec );
         inline void setConfiguration( std::unique_ptr< Core::Configuration > config );
         void initialize();
         void run();

--- a/libs/core/Configuration/Configurables/Configurable.cpp
+++ b/libs/core/Configuration/Configurables/Configurable.cpp
@@ -8,12 +8,24 @@ Core::Configurable::Configurable( const std::string& typeName ) :
     mDirector(),
     mTypeName( typeName )
 {
+    // If either node is hasn't been created yet, just return
     std::shared_ptr< ConfigNode > rootNode = ConfigurationTree::instance()->getRootNode();
+    std::vector< std::shared_ptr< Core::ConfigNode > > childrenNodes = rootNode->getChildren();
+    if ( childrenNodes.empty() )
+        return;
 
+    this->configure( rootNode );
+
+    return;
+}
+
+void Core::Configurable::configure( std::shared_ptr< ConfigNode > rootNode )
+{
     auto configNode = ConfigUtils::getConfigNode( rootNode, mTypeName );
     if ( configNode )
         mConfigNode = *configNode;
 
+    // CONFIGURE LOGGER ---------------------------
     if constexpr ( Utility::CAN_LOG )
     {
         // Check to see if this Configurable has a logger

--- a/libs/core/Configuration/Configurables/Configurable.hpp
+++ b/libs/core/Configuration/Configurables/Configurable.hpp
@@ -20,6 +20,9 @@ namespace Core
         virtual ~Configurable() = default;
 
       protected:
+        void configure( std::shared_ptr< ConfigNode > rootNode );
+
+      protected:
         std::shared_ptr< ConfigNode > mConfigNode;
 
         std::shared_ptr< Utility::Logger > mLogger;

--- a/libs/core/Configuration/Configuration.cpp
+++ b/libs/core/Configuration/Configuration.cpp
@@ -76,6 +76,11 @@ Core::Configuration::Configuration( const ConfigSpec& configSpec ) :
     }
 
     Configuration::setDirectoryInit( DirectoryIDs::CONFIG );
+
+    // Populates ConfigurationTree
+    // Initializes Output Directory
+    // Initializes Assets Directory
+    this->configure();
 }
 
 void Core::Configuration::configure()

--- a/libs/core/Configuration/Configuration.hpp
+++ b/libs/core/Configuration/Configuration.hpp
@@ -43,8 +43,6 @@ namespace Core
       public:
         Configuration( const ConfigSpec& configSpec );
 
-        void configure();
-
         inline void setDirectoryInit( DirectoryIDs directoryID );
 
         inline bool isInitialized();
@@ -55,6 +53,8 @@ namespace Core
         {}
 
       private:
+        void configure();
+
         void initializeOutputDirectory();
         void initializeAssetsDirectory();
 


### PR DESCRIPTION
## Feature: Move Configuration creation to Application

**Description & Motivation** 
This PR cleans up the main function of our program by consolidating the creation of the configuration to the Application Class.

**Changes Made**
- Configuration is now created within the Application constructor

**Tests** 